### PR TITLE
Metadata fix, provide required name attribute

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,6 @@
-maintainer 'Cameron Johnston'
-maintainer_email 'cameron@needle.com'
-description 'installs components required for running selected flavors of selenium'
+name 'selenium'
+maintainer 'Cameron Johnston, Dmytro Makhno, Vasyl Khomenko, Artem Ivantsov'
+maintainer_email 'support@qubell.com'
+description 'installs components required for running selected flavors of selenium and selenium grid'
 version '0.0.3'
 %w{ java python runit }.each { |cb| depends cb }


### PR DESCRIPTION
Should resolve:

```
Fetching 'selenium' from https://github.com/qubell-bazaar/cookbook-qubell-selenium.git (at master)
Ridley::Errors::MissingNameAttribute The metadata at '/tmp/d20140717-8547-yqsscq' does not contain a 'name' attribute. While Chef does not strictly enforce this requirement, Ridley cannot continue without a valid metadata 'name' entry.
```
